### PR TITLE
feat: add ability to pass value to a new app claim

### DIFF
--- a/documentation/reference/adminapi.md
+++ b/documentation/reference/adminapi.md
@@ -79,9 +79,9 @@ Response:
       "attributes": {
         "name": "Authy Person",
         "email": "Hello@authcompanion.com",
-				"metadata": {
-					"company": "Auth Co"
-				},
+        "metadata": {
+          "company": "Auth Co"
+        },
         "app": {
           "tenantID": "1234"
         },
@@ -96,9 +96,9 @@ Response:
       "attributes": {
         "name": "Authy Person 2",
         "email": "Hello2@authcompanion.com",
-				"metadata": {
-					"company": "Auth Co"
-				},
+        "metadata": {
+          "company": "Auth Co"
+        },
         "app": {
           "tenantID": "5678"
         },
@@ -124,7 +124,7 @@ Description: Creates a new user in the Authcompanion database.
 
 Bearer Token Required: `Authorization: Bearer {admin access token}`
 
-Optional: Pass an arbitrary object to data.attributes.metadata which will be made available as a claim on the user's JWT issued after login, this claim is changable using the user token.  Pass an arbitrary object to data.attributes.app which will be made available as a claim on the user's JWT issued after login, this claim is changable only using the admin token.
+Optional: Pass an arbitrary object to data.attributes.metadata which will be made available as a claim on the user's JWT issued after login, this claim is changable using the user token. Pass an arbitrary object to data.attributes.app which will be made available as a claim on the user's JWT issued after login, this claim is changable only using the admin token (aka a "private" claim).
 
 **POST** Request Body:
 
@@ -140,9 +140,9 @@ Optional: Pass an arbitrary object to data.attributes.metadata which will be mad
         "company": "Auth Co"
       },
       "app": {
-          "tenantID": "1234"
-        },
-      "active": 1,
+        "tenantID": "1234"
+      },
+      "active": 1
     }
   }
 }
@@ -162,7 +162,7 @@ Response:
         "company": "Auth Co"
       },
       "app": {
-          "tenantID": "1234"
+        "tenantID": "1234"
       },
       "active": 1,
       "created": "2023-02-02T21:33:53.926Z",
@@ -180,7 +180,7 @@ Description: Updates a single user from the Authcompanion database with the user
 
 Bearer Token Required: `Authorization: Bearer {admin access token}`
 
-Optional: Pass an arbitrary object to data.attributes.metadata which will be made available as a claim on the user's JWT issued after login, this claim is changable using the user token.  Pass an arbitrary object to data.attributes.app which will be made available as a claim on the user's JWT issued after login, this claim is changable only using the admin token.
+Optional: Pass an arbitrary object to data.attributes.metadata which will be made available as a claim on the user's JWT issued after login, this claim is changable using the user token. Pass an arbitrary object to data.attributes.app which will be made available as a claim on the user's JWT issued after login, this claim is changable only using the admin token (aka a "private" claim).
 
 **PATCH** Request Body:
 
@@ -194,11 +194,11 @@ Optional: Pass an arbitrary object to data.attributes.metadata which will be mad
       "password": "supersecret",
       "active": 1,
       "metadata": {
-          "tenant": "tenantID",
+        "tenant": "tenantID"
       },
       "app": {
-          "tenantID": "1234"
-      },
+        "tenantID": "1234"
+      }
     }
   }
 }
@@ -215,10 +215,10 @@ Response:
       "name": "Authy Person",
       "email": "hello@authcompanion.com",
       "metadata": {
-          "tenant": "tenantID",
+        "tenant": "tenantID"
       },
       "app": {
-          "tenantID": "1234"
+        "tenantID": "1234"
       },
       "active": 1,
       "created": "2023-02-02T21:33:53.926Z",

--- a/documentation/reference/adminapi.md
+++ b/documentation/reference/adminapi.md
@@ -80,8 +80,11 @@ Response:
         "name": "Authy Person",
         "email": "Hello@authcompanion.com",
 				"metadata": {
-					"tenant": "tenantID"
+					"company": "Auth Co"
 				},
+        "app": {
+          "tenantID": "1234"
+        },
         "active": 1,
         "created": "2023-02-02T21:33:53.926Z",
         "updated": "2023-02-02T21:33:53.926Z"
@@ -94,8 +97,11 @@ Response:
         "name": "Authy Person 2",
         "email": "Hello2@authcompanion.com",
 				"metadata": {
-					"tenant": "tenantID"
+					"company": "Auth Co"
 				},
+        "app": {
+          "tenantID": "5678"
+        },
         "active": 1,
         "created": "2023-02-02T21:34:37.712Z",
         "updated": "2023-02-02T21:34:37.712Z"
@@ -118,7 +124,7 @@ Description: Creates a new user in the Authcompanion database.
 
 Bearer Token Required: `Authorization: Bearer {admin access token}`
 
-Pass an arbitrary object to data.attributes.metdata which will be made available as a claim on the user's JWT issued after login. 
+Optional: Pass an arbitrary object to data.attributes.metadata which will be made available as a claim on the user's JWT issued after login, this claim is changable using the user token.  Pass an arbitrary object to data.attributes.app which will be made available as a claim on the user's JWT issued after login, this claim is changable only using the admin token.
 
 **POST** Request Body:
 
@@ -131,8 +137,11 @@ Pass an arbitrary object to data.attributes.metdata which will be made available
       "email": "hello@authcompanion.com",
       "password": "supersecret",
       "metadata": {
-        "tenant": "tenantID"
+        "company": "Auth Co"
       },
+      "app": {
+          "tenantID": "1234"
+        },
       "active": 1,
     }
   }
@@ -150,7 +159,10 @@ Response:
       "name": "Authy Person",
       "email": "hello@authcompanion.com",
       "metadata": {
-        "tenant": "tenantID"
+        "company": "Auth Co"
+      },
+      "app": {
+          "tenantID": "1234"
       },
       "active": 1,
       "created": "2023-02-02T21:33:53.926Z",
@@ -168,7 +180,7 @@ Description: Updates a single user from the Authcompanion database with the user
 
 Bearer Token Required: `Authorization: Bearer {admin access token}`
 
-Pass an arbitrary object to data.attributes.metdata which will be made available as a claim on the user's JWT issued after login. 
+Optional: Pass an arbitrary object to data.attributes.metadata which will be made available as a claim on the user's JWT issued after login, this claim is changable using the user token.  Pass an arbitrary object to data.attributes.app which will be made available as a claim on the user's JWT issued after login, this claim is changable only using the admin token.
 
 **PATCH** Request Body:
 
@@ -183,7 +195,10 @@ Pass an arbitrary object to data.attributes.metdata which will be made available
       "active": 1,
       "metadata": {
           "tenant": "tenantID",
-        },
+      },
+      "app": {
+          "tenantID": "1234"
+      },
     }
   }
 }
@@ -201,7 +216,10 @@ Response:
       "email": "hello@authcompanion.com",
       "metadata": {
           "tenant": "tenantID",
-        },
+      },
+      "app": {
+          "tenantID": "1234"
+      },
       "active": 1,
       "created": "2023-02-02T21:33:53.926Z",
       "updated": "2023-02-02T21:33:53.926Z"

--- a/documentation/reference/authapi.md
+++ b/documentation/reference/authapi.md
@@ -17,7 +17,7 @@ Returns Content-Type: application/json
 
 Description: Register a user. Returns a JWT access token and sets a refresh token (as a http only cookie). JWTs are used by your web application to authenticate a user with your backend APIs.
 
-Optional: Pass an arbitrary object to data.attributes.metdata which will be made available as a claim on the user's JWT issued after login.  
+Optional: Pass an arbitrary object to data.attributes.metdata which will be made available as a claim on the user's JWT issued after login (aka a "public" claim).
 
 **POST** Request Body:
 
@@ -29,7 +29,7 @@ Optional: Pass an arbitrary object to data.attributes.metdata which will be made
       "name": "Authy Person",
       "email": "hello@authcompanion.com",
       "password": "mysecretpass",
-			"metadata": {
+      "metadata": {
         "company": "Auth Co"
       }
     }

--- a/documentation/reference/authapi.md
+++ b/documentation/reference/authapi.md
@@ -30,7 +30,7 @@ Optional: Pass an arbitrary object to data.attributes.metdata which will be made
       "email": "hello@authcompanion.com",
       "password": "mysecretpass",
 			"metadata": {
-        "tenant": "tenantID"
+        "company": "Auth Co"
       }
     }
   }
@@ -105,7 +105,7 @@ Bearer Token Required: `Authorization: Bearer {user's access token}`
 
 All fields in the user's attributes are optional.
 
-Pass an arbitrary object to data.attributes.metdata which will be made available as a claim on the user's JWT issued after login.
+Optional: Pass an arbitrary object to data.attributes.metdata which will be made available as a claim on the user's JWT issued after login.
 
 **POST** Request Body:
 
@@ -118,7 +118,7 @@ Pass an arbitrary object to data.attributes.metdata which will be made available
       "email": "hello@authcompanion.com",
       "password": "mysecretpass",
       "metadata": {
-        "tenant": "tenantID"
+        "company": "Auth Co"
       }
     }
   }

--- a/plugins/db/db.js
+++ b/plugins/db/db.js
@@ -4,7 +4,7 @@ import Database from "better-sqlite3";
 import config from "../../config.js";
 import fastifyPlugin from "fastify-plugin";
 
-const VERSION = 3;
+const VERSION = 4;
 
 const migrate = (db, version) => {
   const allFiles = readdirSync("./plugins/db/schema/");

--- a/plugins/db/schema/4__appdata.sql
+++ b/plugins/db/schema/4__appdata.sql
@@ -1,0 +1,7 @@
+BEGIN TRANSACTION;
+
+ALTER TABLE users ADD COLUMN appdata text;
+
+UPDATE authc_version SET version = 4 WHERE version = 3;
+
+COMMIT TRANSACTION;

--- a/services/admin/users/create.js
+++ b/services/admin/users/create.js
@@ -43,7 +43,7 @@ export const createUserHandler = async function (request, reply) {
     const jwtid = randomUUID();
 
     const registerStmt = this.db.prepare(
-      "INSERT INTO users (uuid, name, email, password, metadata, active, jwt_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'), strftime('%Y-%m-%dT%H:%M:%fZ','now')) RETURNING uuid, name, email, metadata, active, created_at, updated_at;"
+      "INSERT INTO users (uuid, name, email, password, metadata, appdata, active, jwt_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'), strftime('%Y-%m-%dT%H:%M:%fZ','now')) RETURNING uuid, name, email, metadata, appdata, active, created_at, updated_at;"
     );
     const user = registerStmt.get(
       uuid,
@@ -51,6 +51,7 @@ export const createUserHandler = async function (request, reply) {
       request.body.data.attributes.email,
       hashpwd,
       JSON.stringify(request.body.data.attributes.metadata),
+      JSON.stringify(request.body.data.attributes.app),
       request.body.data.attributes.active,
       jwtid
     );
@@ -59,6 +60,7 @@ export const createUserHandler = async function (request, reply) {
       name: user.name,
       email: user.email,
       metadata: JSON.parse(user.metadata),
+      app: JSON.parse(user.appdata),
       active: user.active,
       created: user.created_at,
       updated: user.updated_at,

--- a/services/admin/users/list.js
+++ b/services/admin/users/list.js
@@ -10,7 +10,7 @@ export const listUsersHandler = async function (request, reply) {
     const offset = (page - 1) * size;
 
     // Prepare the SQL query and parameters
-    let query = "SELECT uuid, name, email, metadata, active, created_at, updated_at FROM users";
+    let query = "SELECT uuid, name, email, metadata, appdata, active, created_at, updated_at FROM users";
     let params = [];
 
     if (searchEmail) {
@@ -35,6 +35,7 @@ export const listUsersHandler = async function (request, reply) {
           name: user.name,
           email: user.email,
           metadata: JSON.parse(user.metadata),
+          app: JSON.parse(user.appdata),
           active: user.active,
           created: user.created_at,
           updated: user.updated_at,

--- a/services/admin/users/schema/createSchema.js
+++ b/services/admin/users/schema/createSchema.js
@@ -13,6 +13,7 @@ export const createSchema = {
                 email: { type: "string" },
                 password: { type: "string" },
                 metadata: { type: "object" },
+                app: { type: "object" },
                 active: { type: "string" },
               },
               required: ["name", "email", "password", "active"],

--- a/services/admin/users/schema/updateSchema.js
+++ b/services/admin/users/schema/updateSchema.js
@@ -13,6 +13,7 @@ export const updateSchema = {
                 email: { type: "string" },
                 password: { type: "string" },
                 metadata: { type: "object" },
+                app: { type: "object" },
                 active: { type: "string" },
               },
             },

--- a/services/admin/users/update.js
+++ b/services/admin/users/update.js
@@ -54,13 +54,14 @@ export const updateUserHandler = async function (request, reply) {
 
     //Per json-api spec: If a request does not include all of the attributes for a resource, the server MUST interpret the missing attributes as if they were included with their current values. The server MUST NOT interpret missing attributes as null values.
     const updateStmt = this.db.prepare(
-      "UPDATE users SET name = coalesce(?, name), email = coalesce(?, email), password = coalesce(?, password), metadata = coalesce(?, metadata), active = coalesce(?, active), updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE uuid = ? RETURNING uuid, name, email, metadata, active, created_at, updated_at;"
+      "UPDATE users SET name = coalesce(?, name), email = coalesce(?, email), password = coalesce(?, password), metadata = coalesce(?, metadata), appdata = coalesce(?, appdata), active = coalesce(?, active), updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE uuid = ? RETURNING uuid, name, email, metadata, appdata, active, created_at, updated_at;"
     );
     const updatedUser = updateStmt.get(
       request.body.data.attributes.name,
       request.body.data.attributes.email,
       request.body.data.attributes.password,
       JSON.stringify(request.body.data.attributes.metadata),
+      JSON.stringify(request.body.data.attributes.app),
       request.body.data.attributes.active,
       request.params.uuid
     );
@@ -70,6 +71,7 @@ export const updateUserHandler = async function (request, reply) {
       name: updatedUser.name,
       email: updatedUser.email,
       metadata: JSON.parse(user.metadata),
+      app: JSON.parse(user.appdata),
       active: updatedUser.active,
       created: updatedUser.created_at,
       updated: updatedUser.updated_at,

--- a/services/auth/login.js
+++ b/services/auth/login.js
@@ -12,7 +12,7 @@ export const loginHandler = async function (request, reply) {
 
     // Fetch user from database
     const stmt = this.db.prepare(
-      "SELECT uuid, name, email, jwt_id, password, active, created_at, updated_at, metadata FROM users WHERE email = ?;"
+      "SELECT uuid, name, email, jwt_id, password, active, created_at, updated_at, metadata, appdata FROM users WHERE email = ?;"
     );
     const userObj = await stmt.get(request.body.data.attributes.email);
 

--- a/services/auth/profile.js
+++ b/services/auth/profile.js
@@ -28,7 +28,7 @@ export const userProfileHandler = async function (request, reply) {
 
     //Per json-api spec: If a request does not include all of the attributes for a resource, the server MUST interpret the missing attributes as if they were included with their current values. The server MUST NOT interpret missing attributes as null values.
     const updateStmt = this.db.prepare(
-      "UPDATE users SET name = coalesce(?, name), email = coalesce(?, email), password = coalesce(?, password), metadata = coalesce(?, metadata), updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE uuid = ? RETURNING uuid, name, email, metadata, jwt_id, active, created_at, updated_at;"
+      "UPDATE users SET name = coalesce(?, name), email = coalesce(?, email), password = coalesce(?, password), metadata = coalesce(?, metadata), updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE uuid = ? RETURNING uuid, name, email, metadata, appdata, jwt_id, active, created_at, updated_at;"
     );
     const userObj = updateStmt.get(
       request.body.data.attributes.name,

--- a/services/auth/registration.js
+++ b/services/auth/registration.js
@@ -27,7 +27,7 @@ export const registrationHandler = async function (request, reply) {
     const jwtid = randomUUID();
 
     const registerStmt = this.db.prepare(
-      "INSERT INTO users (uuid, name, email, password, metadata, active, jwt_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'), strftime('%Y-%m-%dT%H:%M:%fZ','now')) RETURNING uuid, name, email, metadata, jwt_id, created_at, updated_at;"
+      "INSERT INTO users (uuid, name, email, password, metadata, active, jwt_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'), strftime('%Y-%m-%dT%H:%M:%fZ','now')) RETURNING uuid, name, email, metadata, appdata, jwt_id, created_at, updated_at;"
     );
     const userObj = registerStmt.get(
       uuid,

--- a/utils/jwt.js
+++ b/utils/jwt.js
@@ -36,6 +36,10 @@ export async function makeAccesstoken(userObj, secretKey) {
       claims.metadata = JSON.parse(userObj.metadata);
     }
 
+    if (userObj.appdata !== undefined && userObj.appdata !== null && userObj.appdata !== "{}") {
+      claims.app = JSON.parse(userObj.appdata);
+    }
+
     const jwt = await new jose.SignJWT(claims)
       .setProtectedHeader({ alg: "HS256", typ: "JWT" })
       .setIssuedAt()
@@ -72,6 +76,10 @@ export async function makeRefreshtoken(userObj, secretKey, { recoveryToken = fal
 
     if (userObj.metadata !== undefined && userObj.metadata !== null && userObj.metadata !== "{}") {
       claims.metadata = JSON.parse(userObj.metadata);
+    }
+
+    if (userObj.appdata !== undefined && userObj.appdata !== null && userObj.appdata !== "{}") {
+      claims.app = JSON.parse(userObj.appdata);
     }
 
     const db = new Database(config.DBPATH);


### PR DESCRIPTION
Use the Admin API to update a user's JWT with arbitrary data via a claim called `app`.

You can create private custom claims, which authc provides as `app`, to share information specific to your application. For example, while a public claim  (using [metadata](https://github.com/authcompanion/authcompanion2/pull/15)) might contain generic information like name and email, private claims would be more specific, such as employee ID and department name.

