### PR TITLE
add auth config route

### DIFF
--- a/routes/auth.routes.js
+++ b/routes/auth.routes.js
@@ -22,8 +22,12 @@ import { loginVerificationSchema } from "../services/webAuthn/schemas/loginVerif
 import { registerVerificationSchema } from "../services/webAuthn/schemas/registerVerificationSchema.js";
 
 import { authenticateAuthRequest } from "../utils/authenticate.js";
+import { configHandler } from "../services/auth/config.js";
 
 const authRoutes = async function (fastify, options) {
+  //config routes
+  fastify.get("/config", configHandler);
+
   //authentication API routes
   fastify.post("/register", registrationSchema, registrationHandler);
   fastify.post("/login", loginSchema, loginHandler);

--- a/services/auth/config.js
+++ b/services/auth/config.js
@@ -1,0 +1,21 @@
+const defaultAuthMethods = ["password", "passkey"];
+
+const availableAuthMethods = [...defaultAuthMethods];
+const authOptions = {};
+
+export function registerAuthMethod(methodName, methodConfig) {
+  availableAuthMethods.push(methodName);
+  authOptions[methodName] = methodConfig;
+}
+
+export function resetAuthMethods() {
+  availableAuthMethods = defaultAuthMethods;
+  authOptions = {};
+}
+
+export const configHandler = async function (request, reply) {
+  return {
+    auth_methods: availableAuthMethods,
+    auth_options: authOptions,
+  };
+};

--- a/tools/auth_api_requests.rest
+++ b/tools/auth_api_requests.rest
@@ -76,3 +76,9 @@ content-type: application/json
 Cookie: {{refresh_token}}
 
 {}
+
+### Get Server Config
+GET http://{{host}}/config
+content-type: application/json
+
+{}


### PR DESCRIPTION
A way for authentication plugins to register themselves and a route for the frontend to query what authentication methods are supported by the server.